### PR TITLE
Handle OAuth on iOS in Nav-Window, format-updates

### DIFF
--- a/manifest
+++ b/manifest
@@ -2,11 +2,11 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 0.1.0
+version: 0.2.0
 description: OAuth 2.0 Implementation
 author: Appcelerator
 license: Appcelerator Commercial License
-copyright: Copyright (c) 2016 by Appcelerator,  Inc.
+copyright: Copyright (c) 2016-Present by Appcelerator,  Inc.
 
 
 # these should not be edited
@@ -14,4 +14,4 @@ name: ti.oauth
 moduleid: ti.oauth
 guid: 526b8266-1f47-4caf-81d8-bbd4c76abbba
 platform: commonjs
-minsdk: 2.1.0
+minsdk: 3.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti.oauth",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OAuth 2.0 Implementation for Titanium",
   "main": "./ti.oauth.js",
   "author": {

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,9 @@ OAuth.authorizeImplicitly = function(url, clientId, callback) {
 	});
 
 	if (isiOS === true) {
-		nav.open();
+		nav.open({
+			modal: true
+		});
 	} else {
 		win.open();
 	}
@@ -397,7 +399,9 @@ OAuth.authorizeExplicitly = function(authURL, tokenURL, clientId, clientSecret, 
 	});
 	
 	if (isiOS === true) {
-		nav.open();
+		nav.open({
+			modal: true
+		});
 	} else {
 		win.open();
 	}


### PR DESCRIPTION
Here are the changes included:

- [x] Handle iOS OAuth in `Ti.UI.iOS.Navigation` in order to cancel the current auth-flow (on Android people just navigate back from the activity / window by using the hardware back-button)
- [x] Use the default bar-color (none / white) on iOS to reflect the native defaults and match with the Swift implementation
- [x] Minor changes to the code-format to include a bit more blank lines between the method calls. It made it easier to read for me, I hope that's fine for everyone else as well.