### PR TITLE
Make window-options and callback-url configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti.oauth",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "OAuth 2.0 Implementation for Titanium",
   "main": "./ti.oauth.js",
   "author": {


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-24576

Moving the `AUTH_WINDOW_OPTIONS` and `CALLBACK_URL` to configurable properties of the `OAuth` class, trying to keep full backwards-compatibility by specifying default values. We should remove the default callback-url and window title in 1.0.0 and validate the callback-url before it's usage. The check may even be done earlier, please advice @sgtcoolguy 🙂.